### PR TITLE
Add Spanish backend setup guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,12 @@ cd .. && npm run dev
 
 The application will be accessible at `http://localhost:5173`.
 
+### Guía en español
+
+Si prefieres las instrucciones en español para configurar el backend y utilizar
+la página administrativa, consulta el archivo
+[`docs/backend_setup_es.md`](docs/backend_setup_es.md).
+
 Usage
 Browse Listings: Navigate to the "Inventory" section to view available aircraft.
 List an Aircraft: Go to the "Sell Aircraft" page, fill out the form with your aircraft's details, and submit.

--- a/docs/backend_setup_es.md
+++ b/docs/backend_setup_es.md
@@ -1,0 +1,48 @@
+# Instrucciones para configurar el backend
+
+Este proyecto incluye una API basada en **Node.js** y **Express** ubicada en la carpeta `server`.
+A continuación se describen los pasos básicos para ponerla en marcha y cómo utilizar la interfaz
+administrativa para gestionar la documentación, las imágenes de aviones y las entradas del blog.
+
+## Requisitos previos
+- [Node.js](https://nodejs.org/) 18 o superior
+
+## Instalación
+1. Clonar el repositorio y entrar en la carpeta del proyecto:
+   ```bash
+   git clone <URL-del-repositorio>
+   cd AirTraderPro
+   ```
+2. Instalar las dependencias del frontend y del backend:
+   ```bash
+   npm install
+   cd server && npm install
+   cd ..
+   ```
+
+## Puesta en marcha
+Se recomienda abrir dos terminales.
+
+1. **Iniciar el backend**
+   ```bash
+   cd server
+   npm start
+   ```
+   El servidor quedará disponible en `http://localhost:5000`.
+
+2. **Iniciar el frontend**
+   ```bash
+   npm run dev
+   ```
+   La aplicación web se servirá en `http://localhost:5173`.
+
+## Uso de la página de administración
+1. Accede a `http://localhost:5173/login` e inicia sesión con las credenciales de administrador
+   configuradas en `server/server.js` (`admin/password123` por defecto).
+2. Tras iniciar sesión, podrás crear, editar o eliminar:
+   - Aviones en la sección **Inventory**.
+   - Entradas de blog en la sección **Blog**.
+   Las imágenes subidas se guardan en la carpeta `server/uploads`.
+
+Con estos pasos la aplicación quedará funcionando de forma local, permitiendo gestionar
+la documentación de tus aviones, imágenes y artículos del blog desde la interfaz de backend.


### PR DESCRIPTION
## Summary
- add Spanish backend instructions in docs
- reference the Spanish instructions from README

## Testing
- `npm run lint` *(fails: 'require' is not defined, prop-types, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6848e11843bc8330a59bb065eb5f3274