### PR TITLE
Fix Firestore collection name

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -34,7 +34,8 @@ const upload = multer({ storage });
 
 // Firestore collections
 const planesCollection = db.collection('planes');
-const blogCollection = db.collection('blog');
+// Use a single collection for blog posts
+const blogCollection = db.collection('blogPosts');
 
 // No custom login endpoint. Clients authenticate with Firebase directly.
 


### PR DESCRIPTION
## Summary
- use the `blogPosts` collection in `server/server.js` so the backend matches the React components

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684a50c059908330b416a000efbd0337