### PR TITLE
Add Firestore helpers for blog posts

### DIFF
--- a/src/utils/firestore.js
+++ b/src/utils/firestore.js
@@ -1,4 +1,4 @@
-import { collection, getDocs, doc, getDoc } from 'firebase/firestore';
+import { collection, doc, getDoc, getDocs, query, orderBy } from 'firebase/firestore';
 import { db } from '../firebase';
 
 export const getPlanes = async () => {
@@ -13,12 +13,36 @@ export const getPlane = async (id) => {
 };
 
 export const getBlogPosts = async () => {
-  const snapshot = await getDocs(collection(db, 'blogPosts'));
-  return snapshot.docs.map(doc => ({ id: doc.id, ...doc.data() }));
+  try {
+    const postsQuery = query(collection(db, 'blogPosts'), orderBy('date', 'desc'));
+    const querySnapshot = await getDocs(postsQuery);
+    const posts = querySnapshot.docs.map(doc => ({
+      id: doc.id,
+      ...doc.data(),
+    }));
+    return posts;
+  } catch (error) {
+    console.error('Error fetching blog posts:', error);
+    throw error;
+  }
 };
 
 export const getBlogPost = async (id) => {
-  const docRef = doc(db, 'blogPosts', id);
-  const snap = await getDoc(docRef);
-  return snap.exists() ? { id: snap.id, ...snap.data() } : null;
+  try {
+    const postRef = doc(db, 'blogPosts', id);
+    const docSnap = await getDoc(postRef);
+
+    if (docSnap.exists()) {
+      return {
+        id: docSnap.id,
+        ...docSnap.data(),
+      };
+    } else {
+      console.log('No such blog post found with ID:', id);
+      return null;
+    }
+  } catch (error) {
+    console.error('Error fetching blog post:', error);
+    throw error;
+  }
 };


### PR DESCRIPTION
## Summary
- update Firestore utils with functions for fetching blog posts

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684b6e040bb8833086db5df5fe1eb310